### PR TITLE
Patch allNodes() to generate list of numbers for the node indexes instead of numeric strings, fix JMP indirect mnemonic

### DIFF
--- a/chipsim.js
+++ b/chipsim.js
@@ -143,7 +143,15 @@ function saveString(name, str){
 
 function allNodes(){
 	var res = new Array();
-	for(var i in nodes) if((i!=npwr)&&(i!=ngnd)) res.push(i);
+	var ii = 0;
+	for(var i in nodes) {
+		// Don't feed numeric strings to recalcNodeList(). Numeric
+		// strings can cause a (data dependent) duplicate node number
+		// hiccup when accumulating a node group's list, ie:
+		// group => [ "49", 483, 49 ]
+		ii = Number( i );
+		if((ii!=npwr)&&(ii!=ngnd)) res.push(ii);
+	}
 	return res;
 }
 

--- a/expert-allinone.js
+++ b/expert-allinone.js
@@ -13569,7 +13569,15 @@ function saveString(name, str){
 
 function allNodes(){
 	var res = new Array();
-	for(var i in nodes) if((i!=npwr)&&(i!=ngnd)) res.push(i);
+	var ii = 0;
+	for(var i in nodes) {
+		// Don't feed numeric strings to recalcNodeList(). Numeric
+		// strings can cause a (data dependent) duplicate node number
+		// hiccup when accumulating a node group's list, ie:
+		// group => [ "49", 483, 49 ]
+		ii = Number( i );
+		if((ii!=npwr)&&(ii!=ngnd)) res.push(ii);
+	}
 	return res;
 }
 
@@ -14407,7 +14415,7 @@ var dis6502={
 0x68:"PLA",
 0x69:"ADC #",
 0x6A:"ROR ",
-0x6C:"JMP zp",
+0x6C:"JMP (Abs)",
 0x6D:"ADC Abs",
 0x6E:"ROR Abs",
 0x70:"BVS ",

--- a/macros.js
+++ b/macros.js
@@ -699,7 +699,7 @@ var disassembly={
 0x68:"PLA",
 0x69:"ADC #",
 0x6A:"ROR ",
-0x6C:"JMP zp",
+0x6C:"JMP (Abs)",
 0x6D:"ADC Abs",
 0x6E:"ROR Abs",
 0x70:"BVS ",


### PR DESCRIPTION
Hello,

Fine tune for initial operation: the usage of allNodes() during chip initialization.

Also noticed and corrected the operand for the JMP indirect (6C) mnemonic.

Repeat of original extended commit note follows:

Patches for the general chipsim code and the 6502 emulation.

    For the general chipsim code, allNodes() was constructing a list of
numeric strings for the node indexes instead of a list of numbers for them.
During the first iteration inside recalcNodeList(), the numeric string node
indexes would end up being the first elements of their respective node group
lists. This in turn would allow instances of a duplicate node index to be added
to the node group list. The duplicate in each case would be the numeric
equivalent of the initial numeric string index: indexOf() would not recognize
the string element as being the equivalent of the numeric node index, so the
numeric version would be added also.

For an example (from real log data), a node group list of: [ "49", 483 ] has a
node index of 49 tested against it. indexOf() says "49" is not an occurrence
of 49, so it allows 49 to be added to the list, resulting in: [ "49", 483, 49 ].

All later iterations in recalcNodeList() have always had no problem, as the
recalculation lists always have numeric elements added to them (from the
transistor records).

allNodes() has been changed to ensure that the node indexes are converted to
numbers before addition to the nodes list that it returns.

Note that this niche case of duplication never caused any incorrect operation.
It merely resulted in extra iterations and recursive calls to add connected
nodes to the group list (which would get bounced), and then one extra iteration
of work to evaluate the nodes's value, and then only if there were no ground,
power, pullup, pulldown, or state true nodes in the node group list.

--------

    Corrected the mnemonic for JMP indirect (6C). The operand is two bytes long,
comprising an absolute address instead of a zero page one. There is no JMP zero
page.

End of extended commit note.

Thanks for such an amazing work,
Mark M. Foerster
