### PR TITLE
Corrected node numbers for p6 (V bit) and p7 (N bit) of the status re…

### DIFF
--- a/expert-allinone.js
+++ b/expert-allinone.js
@@ -11879,8 +11879,8 @@ p2: 1553,       // I bit of status register (storage node)
 p3: 348,        // D bit of status register (storage node)
 p4: 1119,       // there is no bit4 in the status register! (not a storage node)
 p5: -1,         // there is no bit5 in the status register! (not a storage node)
-p6: 77,         // V bit of status register (storage node)
-p7: 1370,       // N bit of status register (storage node)
+p6: 1625,       // V bit of status register (storage node)
+p7: 69,         // N bit of status register (storage node)
 
                 // internal bus: status register outputs for push P
 Pout0: 687,
@@ -12102,7 +12102,7 @@ notRnWprepad: 187, // internal signal: to pad, yet to be inverted and retimed
 RnWstretched: 353, // internal signal: control datapad output drivers, aka TRISTATE
 "#DBE": 1035,      // internal signal: formerly from DBE pad (6501)
 cp1: 710,       // internal signal: clock phase 1
-cclk: 943,      // unbonded pad: internal non-overlappying phi2
+cclk: 943,      // unbonded pad: internal non-overlapping phi2
 fetch: 879,     // internal signal
 clearIR: 1077,  // internal signal
 D1x1: 827,      // internal signal: interrupt handler related

--- a/nodenames.js
+++ b/nodenames.js
@@ -153,8 +153,8 @@ p2: 1553,       // I bit of status register (storage node)
 p3: 348,        // D bit of status register (storage node)
 p4: 1119,       // there is no bit4 in the status register! (not a storage node)
 p5: -1,         // there is no bit5 in the status register! (not a storage node)
-p6: 77,         // V bit of status register (storage node)
-p7: 1370,       // N bit of status register (storage node)
+p6: 1625,       // V bit of status register (storage node)
+p7: 69,         // N bit of status register (storage node)
 
                 // internal bus: status register outputs for push P
 Pout0: 687,
@@ -405,7 +405,7 @@ RnWstretched: 353, // internal signal: control datapad output drivers, aka TRIST
 "#DBE": 1035,      // internal signal: formerly from DBE pad (6501)
 "~DBE": 1035,       // automatic alias replacing hash with tilde
 cp1: 710,       // internal signal: clock phase 1
-cclk: 943,      // unbonded pad: internal non-overlappying phi2
+cclk: 943,      // unbonded pad: internal non-overlapping phi2
 fetch: 879,     // internal signal
 clearIR: 1077,  // internal signal
 H1x1: 1042,     // internal signal: drive status byte onto databus


### PR DESCRIPTION
…gister.

    p6 and p7 were duplicates of their respective Pout-named nodes instead of
the phase 1 updated nodes of their storage complexes, as all the other
processor status register bits are (except for the B bit, of course).

    Comment typo correction for cclk.

Hi there. I confirmed the above by drawing the circuit diagrams on paper based on faithfully following the nodes and their connections. Hope you like.
Mark M. Foerster
