### PR TITLE
Added missing '#' and '~' to both copies of the BRtaken node name.

### DIFF
--- a/expert-allinone.js
+++ b/expert-allinone.js
@@ -12282,6 +12282,7 @@ INTG: 1350,     // internal signal: interrupt handler related
 // internal signals: control signals
 nnT2BR: 967,    // doubly inverted
 "#BRtaken": 1544,  // aka #TAKEN
+"~BRtaken": 1544,   // automatic alias replacing hash with tilde
 
 // interrupt and vector related
 NMIP: 1032,

--- a/expert-allinone.js
+++ b/expert-allinone.js
@@ -12281,7 +12281,7 @@ INTG: 1350,     // internal signal: interrupt handler related
 
 // internal signals: control signals
 nnT2BR: 967,    // doubly inverted
-BRtaken: 1544,  // aka #TAKEN
+"#BRtaken": 1544,  // aka #TAKEN
 
 // interrupt and vector related
 NMIP: 1032,

--- a/nodenames.js
+++ b/nodenames.js
@@ -590,8 +590,8 @@ H1x1: 1042,     // internal signal: drive status byte onto databus
 
 // internal signals: control signals
 nnT2BR: 967,    // doubly inverted
-BRtaken: 1544,  // aka #TAKEN
-BRtaken: 1544,   // automatic alias replacing hash with tilde
+"#BRtaken": 1544,  // aka #TAKEN
+"~BRtaken": 1544,   // automatic alias replacing hash with tilde
 
 // internal signals and state: interrupt and vector related
 // segher says:


### PR DESCRIPTION
Another tweak.

Noticed that BRtaken true allows nnT2BR true to "short-circuit" the 6502 clock to T1 after T2, doing opcode fetch of the next instruction instead of branching. It's ~BRtaken, apparently.
--------------

Added missing '#' and '~' to both copies of the BRtaken node name.

The comments with them indicate that the semantics of the node (high when branch
not taken) was already recognized.

pipeBRtaken in the expert version is left untouched, as it is opposite-valued
from #BRtaken, although its meaning is multiplexed by additional influences
(nodenames.js has it named pipeIPCrelated).