### PR TITLE
[6502] Adding expert wire toggles for SO pin

### DIFF
--- a/expertWires.js
+++ b/expertWires.js
@@ -212,6 +212,10 @@ function setupParams(){
 			clockTriggers[value]=[clockTriggers[value],"setLow('rdy');"].join("");
 		} else if(name=="rdy1" && parseInt(value)!=NaN){
 			clockTriggers[value]=[clockTriggers[value],"setHigh('rdy');"].join("");
+		} else if(name=="so0" && parseInt(value)!=NaN){
+			clockTriggers[value]=[clockTriggers[value],"setLow('so');"].join("");
+		} else if(name=="so1" && parseInt(value)!=NaN){
+			clockTriggers[value]=[clockTriggers[value],"setHigh('so');"].join("");
 		} else if(name=="time" && parseInt(value)!=NaN){
 			eventTime=value;
 		} else if(name=="databus" && parseInt(value)!=NaN){


### PR DESCRIPTION
### Summary
Adding a way to signal the SO pin high/low through the query string URL parameters.

### Description
As the summary suggests, I wanted a way to signal the SO pin high/low to better understand how the signals flow from this pin. I'm quite inexperienced in hardware and circuitry, so being able to simulate this is very helpful for me to understand, and I think it could be helpful for others as well.

### How Tested
I tested this and it works on my local machine by pulling the SO pin high then low again. (It appears to need to be pulled back low to actually trigger the set-overflow operation). While I wasn't able to completely follow the node logic, it appears to be working as intended and I see the connections funneling down to the overflow storage node (p6).

Here is the code I tested with:
```
?logmore=so&so1=2&so0=3&steps=16&a=0000&d=ea7001e800
```

In mnemonics, this looks like:
```
    NOP
    BVS SkipInx
    INX
SkipInx:
    BRK
```

The idea here being that if you leave so high (or don't pull so high in the first place) the branch wont be taken and X register will increment by 1.