### PR TITLE
Add missing mouseLeave handler

### DIFF
--- a/expertWires.js
+++ b/expertWires.js
@@ -320,6 +320,11 @@ function mouseUp(e){
 	chipsurround.onmouseup = undefined;
 }
 
+function mouseLeave(e){
+	chipsurround.onmousemove = undefined;
+	chipsurround.onmouseup = undefined;
+}
+
 function setZoom(n){
 	zoom = n;
 	setChipStyle({


### PR DESCRIPTION
This fixes the issue that when the user moves the mouse out of the drawing area while the mouse button is pressed, the mouseUp event doesn't get called and mouseMove stays on even when the button isn't pressed anymore.